### PR TITLE
Initial STM32Pager support

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -35,6 +35,19 @@ impl Default for RaspagerConfig {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct STM32PagerConfig {
+    pub port: String
+}
+
+impl Default for STM32PagerConfig {
+    fn default() -> STM32PagerConfig {
+        STM32PagerConfig {
+            port: String::from("/dev/ttyUSB0")
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct AudioConfig {
     pub level: u8,
     pub inverted: bool,
@@ -74,7 +87,8 @@ pub enum Transmitter {
     Dummy,
     Audio,
     C9000,
-    Raspager
+    Raspager,
+    STM32Pager
 }
 
 impl Default for Transmitter {
@@ -92,7 +106,9 @@ pub struct Config {
     #[serde(default)]
     pub c9000: C9000Config,
     #[serde(default)]
-    pub audio: AudioConfig
+    pub audio: AudioConfig,
+    #[serde(default)]
+    pub stm32pager: STM32PagerConfig,
 }
 
 impl Config {

--- a/src/frontend/assets/index.html
+++ b/src/frontend/assets/index.html
@@ -21,6 +21,7 @@
                 <option>Audio</option>
                 <option>Raspager</option>
                 <option>C9000</option>
+                <option>STM32Pager</option>
               </select>
             </div>
             <div class="form-row">
@@ -63,6 +64,21 @@
                 <input type="number" id="raspager-pa-output-level"
                        v-model="config.raspager.pa_output_level"
                        step="1" min="0" max="63" number class="u8-number">
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="box" v-if="config.transmitter == 'STM32Pager'">
+          <div class="box-header">
+            <h3>STM32Pager Config</h3>
+          </div>
+          <div class="box-content">
+            <div class="form-row">
+              <div class="form-group">
+                <label for="stm32pager-port">Serial Port</label>
+                <input type="text" id="stm32pager-port"
+                       v-model="config.stm32pager.port">
               </div>
             </div>
           </div>

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,9 @@ pub fn run_scheduler(config: Config, scheduler: Scheduler) -> JoinHandle<()> {
             config::Transmitter::Raspager =>
                 scheduler.run(RaspagerTransmitter::new(&config)),
             config::Transmitter::C9000 =>
-                scheduler.run(C9000Transmitter::new(&config))
+                scheduler.run(C9000Transmitter::new(&config)),
+            config::Transmitter::STM32Pager =>
+                scheduler.run(STM32Transmitter::new(&config))
         };
     })
 }

--- a/src/transmitter/mod.rs
+++ b/src/transmitter/mod.rs
@@ -1,12 +1,14 @@
 pub mod dummy;
 pub mod audio;
 pub mod c9000;
+pub mod stm32pager;
 pub mod raspager;
 
 pub use self::dummy::DummyTransmitter;
 pub use self::audio::AudioTransmitter;
 pub use self::c9000::C9000Transmitter;
 pub use self::raspager::RaspagerTransmitter;
+pub use self::stm32pager::STM32Transmitter;
 
 use pocsag::Generator;
 

--- a/src/transmitter/stm32pager/mod.rs
+++ b/src/transmitter/stm32pager/mod.rs
@@ -1,0 +1,3 @@
+mod transmitter;
+
+pub use self::transmitter::STM32Transmitter;

--- a/src/transmitter/stm32pager/transmitter.rs
+++ b/src/transmitter/stm32pager/transmitter.rs
@@ -1,0 +1,58 @@
+use std::{thread, time};
+use serial::{self, SerialPort};
+
+use config::Config;
+use pocsag::Generator;
+use transmitter::Transmitter;
+
+pub struct STM32Transmitter {
+    serial: Box<serial::SerialPort>
+}
+
+impl STM32Transmitter  {
+    pub fn new(config: &Config) -> STM32Transmitter {
+        info!("Initializing STM32Pager transmitter...");
+
+        let mut serial = serial::open(&config.stm32pager.port)
+            .expect("Unable to open serial port");
+
+        serial.configure(&serial::PortSettings {
+            baud_rate: serial::BaudRate::Baud38400,
+            char_size: serial::CharSize::Bits8,
+            parity: serial::Parity::ParityNone,
+            stop_bits: serial::StopBits::Stop1,
+            flow_control: serial::FlowControl::FlowNone
+        }).expect("Unable to configure serial port");
+
+        let transmitter = STM32Transmitter {
+            serial: Box::new(serial)
+        };
+
+        transmitter
+    }
+}
+
+impl Transmitter for STM32Transmitter {
+    fn send(&mut self, gen: Generator) {
+
+        thread::sleep(time::Duration::from_millis(1));
+
+        for word in gen {
+            let bytes = [((word & 0xff000000) >> 24) as u8,
+                         ((word & 0x00ff0000) >> 16) as u8,
+                         ((word & 0x0000ff00) >> 8) as u8,
+                         ((word & 0x000000ff)) as u8];
+
+            if (*self.serial).write(&bytes).is_err() {
+                error!("Unable to write data to the serial port");
+                return;
+            }
+        }
+        // Send End of Transmission packet
+        let eot = [0x17 as u8];
+        if (*self.serial).write(&eot).is_err() {
+            error!("Unable to send end of transmission byte");
+            return;
+        }
+    }
+}


### PR DESCRIPTION
Initial support for a STM32 F446RE Nucleo and Adafruit RFM96HCW based transmitter. 

Code for the STM32 Nucleo can be found at https://git.dk0tu.de/db9mat/STM32_Pager