### PR TITLE
Add revision for Raspberry Pi B+ model

### DIFF
--- a/lib/raspi/src/model.rs
+++ b/lib/raspi/src/model.rs
@@ -38,7 +38,7 @@ impl Model {
             0x4...0x6 | 0xd...0x0f => Model::V1B { rev: 2 },
             0x7...0x9 => Model::V1A,
             0x12 | 0x15 | 0x900021 => Model::V1Aplus,
-            0x10 | 0x13 => Model::V1Bplus,
+            0x10 | 0x13 | 0x900032 => Model::V1Bplus,
             0xA01040 | 0xA01041 => Model::V2B,
             0xA22042 => Model::V2B, // with BCM2837
             0x900092 | 0x900093 | 0x920093 => Model::Zero,


### PR DESCRIPTION
My newly bought RPi model B+ was not supported due to some different Revision in the output of /proc/cpuinfo. The revision 0x900032 was added. See screenshot:

![bildschirmfoto vom 2017-03-05 23-09-08](https://cloud.githubusercontent.com/assets/7112907/23591910/c1f955f2-01f8-11e7-8983-151907b04bbd.png)
