### PR TITLE
Add a separate Audio transmitter for use with RS-232 for PTT

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -49,7 +49,7 @@ impl Default for STM32PagerConfig {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct AudioConfig {
+pub struct AudioGpioConfig {
     #[serde(default)]
     pub device: String,
     pub level: u8,
@@ -59,9 +59,9 @@ pub struct AudioConfig {
     pub tx_delay: usize
 }
 
-impl Default for AudioConfig {
-    fn default() -> AudioConfig {
-        AudioConfig {
+impl Default for AudioGpioConfig {
+    fn default() -> AudioGpioConfig {
+        AudioGpioConfig {
             device: String::from("default"),
             level: 127,
             inverted: false,
@@ -95,7 +95,7 @@ impl Default for MasterConfig {
 #[derive(Serialize, Deserialize, Copy, Clone, Debug)]
 pub enum Transmitter {
     Dummy,
-    Audio,
+    AudioGpio,
     C9000,
     Raspager,
     STM32Pager
@@ -111,7 +111,7 @@ impl fmt::Display for Transmitter {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let name = match *self {
             Transmitter::Dummy => "Dummy",
-            Transmitter::Audio => "Audio",
+            Transmitter::AudioGpio => "AudioGpio",
             Transmitter::C9000 => "C9000",
             Transmitter::Raspager => "RaspagerV1",
             Transmitter::STM32Pager => "STM32Pager"
@@ -129,7 +129,7 @@ pub struct Config {
     #[serde(default)]
     pub c9000: C9000Config,
     #[serde(default)]
-    pub audio: AudioConfig,
+    pub audio_gpio: AudioGpioConfig,
     #[serde(default)]
     pub stm32pager: STM32PagerConfig,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -72,6 +72,33 @@ impl Default for AudioGpioConfig {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct AudioRs232Config {
+    #[serde(default)]
+    pub device: String,
+    pub level: u8,
+    pub inverted: bool,
+    pub ptt_port: String,
+    pub ptt_pin: String,
+    pub ptt_inverted: bool,
+    #[serde(default)]
+    pub tx_delay: usize
+}
+
+impl Default for AudioRs232Config {
+    fn default() -> AudioRs232Config {
+        AudioRs232Config {
+            device: String::from("default"),
+            level: 127,
+            inverted: false,
+            ptt_port: String::from("/dev/ttyUSB0"),
+            ptt_pin: String::from("DTR"),
+            ptt_inverted: false,
+            tx_delay: 0
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct MasterConfig {
     pub server: String,
     pub port: u16,
@@ -96,6 +123,7 @@ impl Default for MasterConfig {
 pub enum Transmitter {
     Dummy,
     AudioGpio,
+    AudioRs232,
     C9000,
     Raspager,
     STM32Pager
@@ -112,6 +140,7 @@ impl fmt::Display for Transmitter {
         let name = match *self {
             Transmitter::Dummy => "Dummy",
             Transmitter::AudioGpio => "AudioGpio",
+            Transmitter::AudioRs232 => "AudioRs232",
             Transmitter::C9000 => "C9000",
             Transmitter::Raspager => "RaspagerV1",
             Transmitter::STM32Pager => "STM32Pager"
@@ -130,6 +159,8 @@ pub struct Config {
     pub c9000: C9000Config,
     #[serde(default)]
     pub audio_gpio: AudioGpioConfig,
+    #[serde(default)]
+    pub audio_rs232: AudioRs232Config,
     #[serde(default)]
     pub stm32pager: STM32PagerConfig,
 }

--- a/src/frontend/assets/index.html
+++ b/src/frontend/assets/index.html
@@ -18,7 +18,7 @@
               <label for="transmitter">Transmitter</label>
               <select id="transmitter" v-model="config.transmitter">
                 <option>Dummy</option>
-                <option>Audio</option>
+                <option>AudioGpio</option>
                 <option>Raspager</option>
                 <option>C9000</option>
                 <option>STM32Pager</option>
@@ -96,42 +96,42 @@
           </div>
         </div>
 
-        <div class="box" v-if="config.transmitter == 'Audio'">
+        <div class="box" v-if="config.transmitter == 'AudioGpio'">
           <div class="box-header">
-            <h3>Audio Config</h3>
+            <h3>AudioGPIO Config</h3>
           </div>
           <div class="box-content">
             <div class="form-row">
               <div class="form-group">
-                <label for="audio-device">ALSA device</label>
-                <input type="text" id="audio-device"
-                       v-model="config.audio.device">
+                <label for="audio_gpio-device">ALSA device</label>
+                <input type="text" id="audio_gpio-device"
+                       v-model="config.audio_gpio.device">
               </div>
             </div>
             <div class="form-row">
               <div class="form-group">
-                <label for="audio-level">Audio Level: {{config.audio.level}}</label>
-                <input type="range" id="audio-level"
-                       v-model="config.audio.level"
+                <label for="audio_gpio-level">Audio Level: {{config.audio_gpio.level}}</label>
+                <input type="range" id="audio_gpio-level"
+                       v-model="config.audio_gpio.level"
                        step="1" min="0" max="127" number>
               </div>
               <div class="form-group">
-                  <label for="audio-inverted">Inverted</label>
-                  <input type="checkbox" id="audio-inverted"
-                         v-model="config.audio.inverted">
+                  <label for="audio_gpio-inverted">Inverted</label>
+                  <input type="checkbox" id="audio_gpio-inverted"
+                         v-model="config.audio_gpio.inverted">
               </div>
             </div>
             <div class="form-row">
               <div class="form-group">
-                <label for="audio-ptt-pin">PTT Pin</label>
-                <input type="number" id="audio-ptt-pin"
-                       v-model="config.audio.ptt_pin"
+                <label for="audio_gpio-ptt-pin">PTT Pin</label>
+                <input type="number" id="audio_gpio-ptt-pin"
+                       v-model="config.audio_gpio.ptt_pin"
                        step="1" min="0" number class="u8-number">
               </div>
               <div class="form-group">
-                  <label for="audio-tx-delay">TX Delay (ms)</label>
-                  <input type="number" id="audio-tx-delay"
-                         v-model="config.audio.tx_delay"
+                  <label for="audio_gpio-tx-delay">TX Delay (ms)</label>
+                  <input type="number" id="audio_gpio-tx-delay"
+                         v-model="config.audio_gpio.tx_delay"
                          step="1" min="0" max="100" number
                          class="u8-number">
               </div>

--- a/src/frontend/assets/index.html
+++ b/src/frontend/assets/index.html
@@ -19,6 +19,7 @@
               <select id="transmitter" v-model="config.transmitter">
                 <option>Dummy</option>
                 <option>AudioGpio</option>
+                <option>AudioRs232</option>
                 <option>Raspager</option>
                 <option>C9000</option>
                 <option>STM32Pager</option>
@@ -132,6 +133,60 @@
                   <label for="audio_gpio-tx-delay">TX Delay (ms)</label>
                   <input type="number" id="audio_gpio-tx-delay"
                          v-model="config.audio_gpio.tx_delay"
+                         step="1" min="0" max="100" number
+                         class="u8-number">
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="box" v-if="config.transmitter == 'AudioRs232'">
+          <div class="box-header">
+            <h3>AudioRS232 Config</h3>
+          </div>
+          <div class="box-content">
+            <div class="form-row">
+              <div class="form-group">
+                <label for="audio_rs232-device">ALSA device</label>
+                <input type="text" id="audio_rs232-device"
+                       v-model="config.audio_rs232.device">
+              </div>
+            </div>
+            <div class="form-row">
+              <div class="form-group">
+                <label for="audio_rs232-level">Audio Level: {{config.audio_rs232.level}}</label>
+                <input type="range" id="audio_rs232-level"
+                       v-model="config.audio_rs232.level"
+                       step="1" min="0" max="127" number>
+              </div>
+              <div class="form-group">
+                  <label for="audio_rs232-inverted">Audio Inverted</label>
+                  <input type="checkbox" id="audio_rs232-inverted"
+                         v-model="config.audio_rs232.inverted">
+              </div>
+            </div>
+            <div class="form-row">
+              <div class="form-group">
+                <label for="audio_rs232-ptt-port">Serial Port</label>
+                <input type="text" id="audio_rs232-ptt-port"
+                       v-model="config.audio_rs232.ptt_port">
+              </div>
+              <div class="form-group">
+                <label for="audio_rs232-ptt-pin">PTT Pin</label>
+                <select id="audio_rs232-ptt-pin" v-model="config.audio_rs232.ptt_pin">
+                  <option>DTR</option>
+                  <option>RTS</option>
+                </select>
+              </div>
+              <div class="form-group">
+                  <label for="audio_rs232-ptt-inverted">PTT Inverted</label>
+                  <input type="checkbox" id="audio_rs232-ptt-inverted"
+                         v-model="config.audio_rs232.ptt_inverted">
+              </div>
+              <div class="form-group">
+                  <label for="audio_rs232-tx-delay">TX Delay (ms)</label>
+                  <input type="number" id="audio_rs232-tx-delay"
+                         v-model="config.audio_rs232.tx_delay"
                          step="1" min="0" max="100" number
                          class="u8-number">
               </div>

--- a/src/frontend/assets/main.js
+++ b/src/frontend/assets/main.js
@@ -10,7 +10,7 @@ var vm = new Vue({
         socket: null,
         config: {
             master: {},
-            audio: {},
+            audio_gpio: {},
             c9000: {},
             raspager: {}
         },

--- a/src/pocsag/scheduler.rs
+++ b/src/pocsag/scheduler.rs
@@ -52,8 +52,8 @@ impl Scheduler {
             match config.transmitter {
                 Transmitter::Dummy =>
                     scheduler.run(DummyTransmitter::new(&config)),
-                Transmitter::Audio =>
-                    scheduler.run(AudioTransmitter::new(&config)),
+                Transmitter::AudioGpio =>
+                    scheduler.run(AudioGpioTransmitter::new(&config)),
                 Transmitter::Raspager =>
                     scheduler.run(RaspagerTransmitter::new(&config)),
                 Transmitter::C9000 =>

--- a/src/pocsag/scheduler.rs
+++ b/src/pocsag/scheduler.rs
@@ -54,6 +54,8 @@ impl Scheduler {
                     scheduler.run(DummyTransmitter::new(&config)),
                 Transmitter::AudioGpio =>
                     scheduler.run(AudioGpioTransmitter::new(&config)),
+                Transmitter::AudioRs232 =>
+                    scheduler.run(AudioRs232Transmitter::new(&config)),
                 Transmitter::Raspager =>
                     scheduler.run(RaspagerTransmitter::new(&config)),
                 Transmitter::C9000 =>

--- a/src/transmitter/audio/mod.rs
+++ b/src/transmitter/audio/mod.rs
@@ -1,3 +1,0 @@
-mod transmitter;
-
-pub use self::transmitter::AudioTransmitter;

--- a/src/transmitter/audio_gpio/mod.rs
+++ b/src/transmitter/audio_gpio/mod.rs
@@ -1,0 +1,3 @@
+mod transmitter;
+
+pub use self::transmitter::AudioGpioTransmitter;

--- a/src/transmitter/audio_gpio/transmitter.rs
+++ b/src/transmitter/audio_gpio/transmitter.rs
@@ -12,7 +12,7 @@ const BAUD_RATE: usize = 1200;
 const SAMPLE_RATE: usize = 48000;
 const SAMPLES_PER_BIT: usize = SAMPLE_RATE/BAUD_RATE;
 
-pub struct AudioTransmitter {
+pub struct AudioGpioTransmitter {
     device: String,
     ptt_pin: Pin,
     inverted: bool,
@@ -20,24 +20,24 @@ pub struct AudioTransmitter {
     tx_delay: usize
 }
 
-impl AudioTransmitter {
-    pub fn new(config: &Config) -> AudioTransmitter {
-        info!("Initializing audio transmitter...");
+impl AudioGpioTransmitter {
+    pub fn new(config: &Config) -> AudioGpioTransmitter {
+        info!("Initializing audio GPIO transmitter...");
         info!("Detected {}", Model::get());
 
         let gpio = Gpio::new().expect("Failed to map GPIO");
 
-        let device = match &*config.audio.device {
+        let device = match &*config.audio_gpio.device {
             "" => String::from("default"),
             other => other.to_owned()
         };
 
-        let mut transmitter = AudioTransmitter {
+        let mut transmitter = AudioGpioTransmitter {
             device: device,
-            ptt_pin: gpio.pin(config.audio.ptt_pin, Direction::Output),
-            inverted: config.audio.inverted,
-            level: config.audio.level,
-            tx_delay: config.audio.tx_delay
+            ptt_pin: gpio.pin(config.audio_gpio.ptt_pin, Direction::Output),
+            inverted: config.audio_gpio.inverted,
+            level: config.audio_gpio.level,
+            tx_delay: config.audio_gpio.tx_delay
         };
 
         if transmitter.level > 127 {
@@ -50,7 +50,7 @@ impl AudioTransmitter {
     }
 }
 
-impl Transmitter for AudioTransmitter {
+impl Transmitter for AudioGpioTransmitter {
     fn send(&mut self, gen: Generator) {
         self.ptt_pin.set_high();
 

--- a/src/transmitter/audio_rs232/mod.rs
+++ b/src/transmitter/audio_rs232/mod.rs
@@ -1,0 +1,3 @@
+mod transmitter;
+
+pub use self::transmitter::AudioRs232Transmitter;

--- a/src/transmitter/audio_rs232/transmitter.rs
+++ b/src/transmitter/audio_rs232/transmitter.rs
@@ -1,0 +1,150 @@
+use std::process::{Command, Stdio};
+use std::io::Write;
+use std::thread::sleep;
+use std::time::Duration;
+use serial::{self};
+
+use pocsag::Generator;
+use config::Config;
+use transmitter::Transmitter;
+
+const BAUD_RATE: usize = 1200;
+const SAMPLE_RATE: usize = 48000;
+const SAMPLES_PER_BIT: usize = SAMPLE_RATE/BAUD_RATE;
+
+pub struct AudioRs232Transmitter {
+    device: String,
+    ptt_port: String,
+    ptt_pin: String,
+    ptt_inverted: bool,
+    inverted: bool,
+    level: u8,
+    tx_delay: usize,
+    serial: Box<serial::SerialPort>
+}
+
+impl AudioRs232Transmitter {
+    pub fn new(config: &Config) -> AudioRs232Transmitter {
+        info!("Initializing audio RS-232 transmitter...");
+
+        let ptt_port = &config.audio_rs232.ptt_port;
+        let ptt_pin = &config.audio_rs232.ptt_pin;
+        info!("Initializing serial port {:?} pin {:?}", ptt_port, ptt_pin);
+        let serial = serial::open(&config.audio_rs232.ptt_port)
+            .expect("Unable to open serial port");
+
+        let device = match &*config.audio_rs232.device {
+            "" => String::from("default"),
+            other => other.to_owned()
+        };
+
+        let mut transmitter = AudioRs232Transmitter {
+            device: device,
+            ptt_port: config.audio_rs232.ptt_port.to_owned(),
+            ptt_pin: config.audio_rs232.ptt_pin.to_owned(),
+            ptt_inverted: config.audio_rs232.ptt_inverted.to_owned(),
+            inverted: config.audio_rs232.inverted,
+            level: config.audio_rs232.level,
+            tx_delay: config.audio_rs232.tx_delay,
+            serial: Box::new(serial)
+        };
+
+        if transmitter.level > 127 {
+            transmitter.level = 127;
+        }
+
+        if transmitter.ptt_pin == "DTR" {
+            if transmitter.ptt_inverted == true {
+                transmitter.serial.set_dtr(true)
+                   .expect("Error setting PTT pin");
+            } else {
+                transmitter.serial.set_dtr(false)
+                   .expect("Error setting PTT pin");
+            }
+        } else if transmitter.ptt_pin == "RTS" {
+            if transmitter.ptt_inverted == true {
+                transmitter.serial.set_rts(true)
+                   .expect("Error setting PTT pin");
+            } else {
+                transmitter.serial.set_rts(false)
+                   .expect("Error setting PTT pin");
+            }
+        }
+
+       transmitter
+    }
+}
+
+impl Transmitter for AudioRs232Transmitter {
+    fn send(&mut self, gen: Generator) {
+        if self.ptt_pin == "DTR" {
+            if self.ptt_inverted == true {
+                self.serial.set_dtr(false)
+                   .expect("Error setting PTT pin");
+            } else {
+                self.serial.set_dtr(true)
+                   .expect("Error setting PTT pin");
+            }
+        } else if self.ptt_pin == "RTS" {
+            if self.ptt_inverted == true {
+                self.serial.set_rts(false)
+                   .expect("Error setting PTT pin");
+            } else {
+                self.serial.set_rts(true)
+                   .expect("Error setting PTT pin");
+            }
+        }
+
+        sleep(Duration::from_millis(self.tx_delay as u64));
+
+        let mut buffer: Vec<u8> = Vec::with_capacity(SAMPLE_RATE);
+        let low_level = 127 - self.level;
+        let high_level = 128 + self.level;
+
+        for word in gen {
+            for i in 0..32 {
+                let bit = (word & (1 << (31 - i))) != 0;
+                if (!self.inverted && bit) || (self.inverted && !bit) {
+                    buffer.extend_from_slice(&[low_level; SAMPLES_PER_BIT]);
+                }
+                else {
+                    buffer.extend_from_slice(&[high_level; SAMPLES_PER_BIT]);
+                }
+            }
+        }
+
+        let mut child = Command::new("aplay")
+            .stdin(Stdio::piped())
+            .args(&["-t", "raw", "-N", "-f", "U8", "-c", "1"])
+            .args(&["-r", &*format!("{}", SAMPLE_RATE)])
+            .args(&["-D", &*self.device])
+            .spawn()
+            .expect("Failed to start aplay");
+
+        child.stdin.as_mut()
+            .expect("Failed to get aplay stdin")
+            .write_all(buffer.as_slice())
+            .expect("Failed to write to aplay stdin");
+
+        child.wait().expect("Failed to wait for aplay");
+
+        if self.ptt_pin == "DTR" {
+            if self.ptt_inverted == true {
+                self.serial.set_dtr(true)
+                   .expect("Error setting PTT pin");
+            } else {
+                self.serial.set_dtr(false)
+                   .expect("Error setting PTT pin");
+            }
+        } else if self.ptt_pin == "RTS" {
+            if self.ptt_inverted == true {
+                self.serial.set_rts(true)
+                   .expect("Error setting PTT pin");
+            } else {
+                self.serial.set_rts(false)
+                   .expect("Error setting PTT pin");
+            }
+        }
+
+    }
+}

--- a/src/transmitter/audio_rs232/transmitter.rs
+++ b/src/transmitter/audio_rs232/transmitter.rs
@@ -14,7 +14,6 @@ const SAMPLES_PER_BIT: usize = SAMPLE_RATE/BAUD_RATE;
 
 pub struct AudioRs232Transmitter {
     device: String,
-    ptt_port: String,
     ptt_pin: String,
     ptt_inverted: bool,
     inverted: bool,
@@ -40,7 +39,6 @@ impl AudioRs232Transmitter {
 
         let mut transmitter = AudioRs232Transmitter {
             device: device,
-            ptt_port: config.audio_rs232.ptt_port.to_owned(),
             ptt_pin: config.audio_rs232.ptt_pin.to_owned(),
             ptt_inverted: config.audio_rs232.ptt_inverted.to_owned(),
             inverted: config.audio_rs232.inverted,

--- a/src/transmitter/mod.rs
+++ b/src/transmitter/mod.rs
@@ -1,11 +1,13 @@
 pub mod dummy;
 pub mod audio_gpio;
+pub mod audio_rs232;
 pub mod c9000;
 pub mod stm32pager;
 pub mod raspager;
 
 pub use self::dummy::DummyTransmitter;
 pub use self::audio_gpio::AudioGpioTransmitter;
+pub use self::audio_rs232::AudioRs232Transmitter;
 pub use self::c9000::C9000Transmitter;
 pub use self::raspager::RaspagerTransmitter;
 pub use self::stm32pager::STM32Transmitter;

--- a/src/transmitter/mod.rs
+++ b/src/transmitter/mod.rs
@@ -1,11 +1,11 @@
 pub mod dummy;
-pub mod audio;
+pub mod audio_gpio;
 pub mod c9000;
 pub mod stm32pager;
 pub mod raspager;
 
 pub use self::dummy::DummyTransmitter;
-pub use self::audio::AudioTransmitter;
+pub use self::audio_gpio::AudioGpioTransmitter;
 pub use self::c9000::C9000Transmitter;
 pub use self::raspager::RaspagerTransmitter;
 pub use self::stm32pager::STM32Transmitter;


### PR DESCRIPTION
I added a separate Audio transmitter that switches PTT via RTS/DTR on a serial port. The old Audio transmitter was renamed to AudioGpio and the new one is AudioRs232. See https://github.com/rwth-afu/RustPager/issues/41