### PR TITLE
Fix BCH(31,21) check bit calculation

### DIFF
--- a/src/pocsag/generator.rs
+++ b/src/pocsag/generator.rs
@@ -63,7 +63,7 @@ impl<'a> Generator<'a> {
 // Calculate the CRC for a codeword and return the updated codeword.
 fn crc(codeword: u32) -> u32 {
     let mut crc = codeword;
-    for i in 0..=21 {
+    for i in 0..21 {
         if (crc & (0x80000000 >> i)) != 0 {
             crc ^= 0xED200000 >> i;
         }
@@ -211,6 +211,177 @@ impl<'a> Iterator for Generator<'a> {
             (_, State::Completed) => {
                 self.codewords -= 1;
                 Some(IDLE_WORD)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::message::{Message as OuterMessage, MessageProvider};
+
+    // ---- BCH(31,21) verification helpers ----
+
+    // Re-divide a 32-bit POCSAG codeword by the BCH(31,21) generator
+    // polynomial g(x) = x^10 + x^9 + x^8 + x^6 + x^5 + x^3 + 1.
+    // A correctly encoded codeword has remainder 0.
+    fn bch_syndrome(codeword: u32) -> u32 {
+        let mut c = codeword & !1u32; // exclude the parity bit at position 0
+        for i in 0..21 {
+            if (c & (0x80000000u32 >> i)) != 0 {
+                c ^= 0xED200000u32 >> i;
+            }
+        }
+        (c >> 1) & 0x3FF
+    }
+
+    fn even_parity_bit(codeword: u32) -> u32 {
+        let mut p = codeword;
+        p ^= p >> 1; p ^= p >> 2; p ^= p >> 4; p ^= p >> 8; p ^= p >> 16;
+        p & 1
+    }
+
+    // Independent BCH encoder in the multimon-ng / libbch_pocsag "left-shift"
+    // style. Used to cross-check our right-shift implementation.
+    fn bch_encode_reference(cw: u32) -> u32 {
+        let masked = cw & 0xFFFFF800; // clear BCH+parity region
+        let mut local = masked;
+        for _ in 0..21 {
+            if local & 0x80000000 != 0 {
+                local ^= 0xED200000;
+            }
+            local <<= 1;
+        }
+        let mut with_bch = masked | (local >> 21);
+        if even_parity_bit(with_bch) == 1 {
+            with_bch |= 1;
+        }
+        with_bch
+    }
+
+    // ---- Regression vectors ----
+
+    // The well-known POCSAG IDLE codeword must round-trip:
+    // strip BCH+parity, re-encode, and the result must equal IDLE_WORD.
+    #[test]
+    fn idle_word_roundtrips() {
+        let raw = IDLE_WORD & 0xFFFFF800;
+        let encoded = parity(crc(raw));
+        assert_eq!(encoded, IDLE_WORD,
+            "IDLE_WORD round-trip: got 0x{:08X}, expected 0x{:08X}",
+            encoded, IDLE_WORD);
+    }
+
+    // Explicit input/output pairs.  Each expected value is also verified to
+    // be a true BCH(31,21) codeword (syndrome zero) with even parity, so the
+    // assertion catches both encoder bugs and stale test vectors.
+    //
+    //   data=0x000001 -> only bit 0 of the 21-bit data set (codeword bit 11)
+    //     x^10 mod g = x^9+x^8+x^6+x^5+x^3+1 -> BCH at bits 10..1 = 0x6D2
+    //     parity over 0x800|0x6D2 is odd, so bit 0=1 -> 0xED3
+    //   data=0x100000 -> only bit 20 of data set (codeword bit 31, message
+    //     identifier).  x^30 mod g = 0x3B4 -> BCH at bits 10..1 = 0x768
+    //     parity is odd, bit 0=1 -> 0x80000769
+    #[test]
+    fn known_codewords() {
+        let cases: &[(u32, u32)] = &[
+            (0x000000, 0x00000000),
+            (0x000001, 0x00000ED3),
+            (0x100000, 0x80000769),
+        ];
+        for &(data, expected) in cases {
+            let raw = data << 11;
+            let got = parity(crc(raw));
+            assert_eq!(got, expected,
+                "data=0x{:06X}: got 0x{:08X}, expected 0x{:08X}",
+                data, got, expected);
+            // Sanity-check that the expected value really is a valid codeword.
+            assert_eq!(bch_syndrome(expected), 0);
+            assert_eq!(even_parity_bit(expected), 0);
+        }
+    }
+
+    // The original bug (22-iteration loop) produced wrong BCH bits whenever
+    // bit 10 of the correct check was 1.  Exhaustively verify our crc() over
+    // every 21-bit input, comparing against the independent left-shift
+    // reference encoder.
+    #[test]
+    fn crc_matches_reference_encoder_for_all_inputs() {
+        for data in 0u32..(1u32 << 21) {
+            let raw = data << 11;
+            let ours = parity(crc(raw));
+            let reference = bch_encode_reference(raw);
+            assert_eq!(ours, reference,
+                "mismatch at data=0x{:06X}: ours=0x{:08X}, ref=0x{:08X}",
+                data, ours, reference);
+        }
+    }
+
+    // Every codeword our crc()+parity() produces must satisfy the BCH(31,21)
+    // syndrome check and have even parity over all 32 bits.
+    #[test]
+    fn all_codewords_have_valid_bch_and_parity() {
+        for data in 0u32..(1u32 << 21) {
+            let raw = data << 11;
+            let cw = parity(crc(raw));
+            assert_eq!(bch_syndrome(cw), 0,
+                "BCH syndrome nonzero for data=0x{:06X}, cw=0x{:08X}",
+                data, cw);
+            assert_eq!(even_parity_bit(cw), 0,
+                "parity not even for data=0x{:06X}, cw=0x{:08X}",
+                data, cw);
+        }
+    }
+
+    // ---- End-to-end Generator regression ----
+    //
+    // Drive the full Generator and check that every emitted address word and
+    // message word is a valid BCH(31,21) codeword. Sweeps message lengths and
+    // sub-RIC values so the codeword data field varies widely.
+
+    struct EmptyProvider;
+    impl MessageProvider for EmptyProvider {
+        fn next(&mut self, _count: usize) -> Option<OuterMessage> {
+            None
+        }
+    }
+
+    fn generate_codewords(ric: u32, length: usize) -> Vec<u32> {
+        let data: String = std::iter::repeat('A').take(length).collect();
+        let msg = Message {
+            mtype: MessageType::AlphaNum,
+            speed: 1200,
+            ric,
+            func: 3,
+            data,
+        };
+        let mut provider = EmptyProvider;
+        Generator::new(&mut provider, msg).collect()
+    }
+
+    #[test]
+    fn generator_emits_valid_bch_codewords() {
+        // Skip preamble (0xAAAAAAAA) and sync words; everything else must be
+        // a valid BCH+parity codeword.
+        for length in 0..=30usize {
+            for ric_lower in 0..=7u32 {
+                let ric = 0x0010_0000 | ric_lower;
+                for (idx, &cw) in generate_codewords(ric, length)
+                    .iter().enumerate()
+                {
+                    if cw == SYNC_WORD || cw == 0xAAAAAAAA {
+                        continue;
+                    }
+                    assert_eq!(bch_syndrome(cw), 0,
+                        "BCH syndrome nonzero at idx {} (length={}, \
+                         ric_lower={}, cw=0x{:08X})",
+                        idx, length, ric_lower, cw);
+                    assert_eq!(even_parity_bit(cw), 0,
+                        "parity not even at idx {} (length={}, \
+                         ric_lower={}, cw=0x{:08X})",
+                        idx, length, ric_lower, cw);
+                }
             }
         }
     }


### PR DESCRIPTION
_I found and fixed this one manually, then used Claude to generate the test suite based on my own BCH encoder-decoder (https://github.com/philpem/libbch_pocsag). All LLM-written code (the test suite) has been verified by myself. If LLM-generated code is not permitted then please advise and I'll re-submit the human-made parts only._

In summary: the UniPager `crc()` loop runs one too many times, generating erroneous check bits which will cause a fully-compliant POCSAG receiver to erroneously flip the message/address identifier bit.

In detail:

- The crc() loop iterates 22 times instead of 21. 
- On the 22nd iteration it checks bit 10, which is in the BCH bits region (not a data bit).
- If bit 10 is set, it XORs the generator polynomial into bits `10..0`. (because we've already XORed in the 21 data bits, there's a 50% chance of this happening)
- That erroneous XOR corrupts the BCH bits and (in turn) the parity bit.

When the receiver applies error correction to incoming codewords, it will see what looks like a flipped message/address identifier bit. It'll correct this, turning message bytes into address bytes and vice versa. Receivers which ignore BCH or only apply it conditionally will get the correct data bits.

The idle word happens to have bit-10 of its BCH = 0, so it wouldn't trip the bug if it was used as a test vector.

Tests:
  * `idle_word_roundtrips` (spot-check round-trip test)
  * `known_codewords` (test vectors)
  * `crc_matches_reference_encoder_for_all_inputs` (cross-check against a different BCH encoder based on mine for all possible data bit inputs)
  * `all_codewords_have_valid_bch_and_parity` (re-divide the codeword by the generator `g(x)` and assert the syndrome is zero i.e. no error bits)
  * `generator_emits_valid_bch_codewords` (end-to-end test)