### PR TITLE
Send an idle batch at the end of every transmission to work around receiver quirks

### DIFF
--- a/src/pocsag/generator.rs
+++ b/src/pocsag/generator.rs
@@ -28,7 +28,9 @@ pub struct Generator<'a> {
     // Number of codewords left in current batch
     codewords: u8,
     // Number of codewords generated
-    count: usize
+    count: usize,
+    // Number of terminator (sync + idle) batches emitted after completion
+    idle_batches_sent: u8
 }
 
 impl<'a> Generator<'a> {
@@ -40,7 +42,8 @@ impl<'a> Generator<'a> {
             messages,
             message: Some(first_msg),
             codewords: PREAMBLE_LENGTH,
-            count: 0
+            count: 0,
+            idle_batches_sent: 0
         }
     }
 
@@ -54,7 +57,10 @@ impl<'a> Generator<'a> {
 
         match self.message
         {
-            Some(_) => State::AddressWord,
+            Some(_) => {
+                self.idle_batches_sent = 0;
+                State::AddressWord
+            }
             None => State::Completed,
         }
     }
@@ -91,8 +97,19 @@ impl<'a> Iterator for Generator<'a> {
 
         match (self.codewords, self.state)
         {
-            // Stop if no codewords are left and everything is completed.
-            (0, State::Completed) => None,
+            // Stop only after at least one full terminator batch (sync + 16
+            // idles) has followed the last message word. This guarantees
+            // receivers see a non-message-word codeword after the final
+            // message word and have carrier stability to commit it.
+            (0, State::Completed) if self.idle_batches_sent > 0 => None,
+
+            // End of batch in the completed state: emit one trailing sync
+            // word and begin a terminator batch of 16 idle words.
+            (0, State::Completed) => {
+                self.codewords = 16;
+                self.idle_batches_sent += 1;
+                Some(SYNC_WORD)
+            }
 
             // The preamble is completed.
             // Send the sync word and start a new batch with 16 codewords.
@@ -211,6 +228,68 @@ impl<'a> Iterator for Generator<'a> {
             (_, State::Completed) => {
                 self.codewords -= 1;
                 Some(IDLE_WORD)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::message::{Message as OuterMessage, MessageProvider};
+    use crate::pocsag::{Message, MessageType};
+
+    struct EmptyProvider;
+
+    impl MessageProvider for EmptyProvider {
+        fn next(&mut self, _count: usize) -> Option<OuterMessage> {
+            None
+        }
+    }
+
+    fn collect_all(ric: u32, length: usize) -> Vec<u32> {
+        let data: String = std::iter::repeat('A').take(length).collect();
+        let msg = Message {
+            mtype: MessageType::AlphaNum,
+            speed: 1200,
+            ric,
+            func: 3,
+            data,
+        };
+        let mut provider = EmptyProvider;
+        Generator::new(&mut provider, msg).collect()
+    }
+
+    #[test]
+    fn terminator_follows_last_message_word() {
+        for length in 1..=60usize {
+            for ric_lower in 0..=7u32 {
+                // Build a RIC where the lower three bits vary; the upper bits
+                // are arbitrary but valid.
+                let ric = 0x0010_0000 | ric_lower;
+                let cws = collect_all(ric, length);
+
+                assert!(!cws.is_empty(),
+                    "no codewords produced (length={}, ric_lower={})",
+                    length, ric_lower);
+
+                // The final codeword in the stream must not be a message word.
+                let last = *cws.last().unwrap();
+                assert_eq!(last & 0x80000000, 0,
+                    "last codeword is a message word \
+                     (length={}, ric_lower={}, last=0x{:08X})",
+                    length, ric_lower, last);
+
+                // At least one IDLE_WORD must appear between the last message
+                // word in the stream and the end.
+                let last_msg_idx = cws.iter()
+                    .rposition(|&w| w & 0x80000000 != 0)
+                    .expect("stream must contain at least one message word");
+                let after = &cws[last_msg_idx + 1..];
+                assert!(after.iter().any(|&w| w == IDLE_WORD),
+                    "no idle word follows the last message word \
+                     (length={}, ric_lower={}, tail_len={})",
+                    length, ric_lower, after.len());
             }
         }
     }

--- a/src/pocsag/generator.rs
+++ b/src/pocsag/generator.rs
@@ -12,7 +12,14 @@ enum State {
     Preamble,
     AddressWord,
     MessageWord(usize, Encoding),
-    Completed
+    // Fill the rest of the current batch with idles, then transition to
+    // Terminator on the batch boundary.
+    Completed,
+    // Emit idle words in a final batch following a trailing sync word, then
+    // end the iterator. Guarantees at least one full sync+idle batch follows
+    // the last message word so receivers see a clear end-of-message and the
+    // carrier stays up long enough to commit it.
+    Terminator
 }
 
 /// POCSAG Generator
@@ -28,9 +35,7 @@ pub struct Generator<'a> {
     // Number of codewords left in current batch
     codewords: u8,
     // Number of codewords generated
-    count: usize,
-    // Number of terminator (sync + idle) batches emitted after completion
-    idle_batches_sent: u8
+    count: usize
 }
 
 impl<'a> Generator<'a> {
@@ -42,8 +47,7 @@ impl<'a> Generator<'a> {
             messages,
             message: Some(first_msg),
             codewords: PREAMBLE_LENGTH,
-            count: 0,
-            idle_batches_sent: 0
+            count: 0
         }
     }
 
@@ -57,10 +61,7 @@ impl<'a> Generator<'a> {
 
         match self.message
         {
-            Some(_) => {
-                self.idle_batches_sent = 0;
-                State::AddressWord
-            }
+            Some(_) => State::AddressWord,
             None => State::Completed,
         }
     }
@@ -97,17 +98,14 @@ impl<'a> Iterator for Generator<'a> {
 
         match (self.codewords, self.state)
         {
-            // Stop only after at least one full terminator batch (sync + 16
-            // idles) has followed the last message word. This guarantees
-            // receivers see a non-message-word codeword after the final
-            // message word and have carrier stability to commit it.
-            (0, State::Completed) if self.idle_batches_sent > 0 => None,
+            // Terminator batch finished: end the iterator.
+            (0, State::Terminator) => None,
 
-            // End of batch in the completed state: emit one trailing sync
-            // word and begin a terminator batch of 16 idle words.
+            // End of the last batch with a pending message-end: emit the
+            // trailing sync word and enter the terminator batch.
             (0, State::Completed) => {
                 self.codewords = 16;
-                self.idle_batches_sent += 1;
+                self.state = State::Terminator;
                 Some(SYNC_WORD)
             }
 
@@ -224,8 +222,9 @@ impl<'a> Iterator for Generator<'a> {
                 Some(parity(crc(0x80000000 | (codeword << 11))))
             }
 
-            // Everything is done. Send idle words until the batch is complete.
-            (_, State::Completed) => {
+            // No more messages. Fill the rest of the current batch (Completed)
+            // or the terminator batch (Terminator) with idle words.
+            (_, State::Completed) | (_, State::Terminator) => {
                 self.codewords -= 1;
                 Some(IDLE_WORD)
             }


### PR DESCRIPTION
_This one is the result of chasing a message truncation bug and feeding the symptoms and the ETSI RPC-1/POCSAG spec into Claude. It's LLM-generated. If that's not acceptable to the project then please let me know and I'll redo the PR. All LLM-generated code has been checked by myself._

Some receivers corrupt the last message codeword (and thus the last few characters of a text message) if it ends in the last frame/codeword of a batch.

If the message ends in the last frame of a batch, there are no idle or address codewords transmitted after. The modulation stops at the end of the final message CW). This causes some receivers to misbehave:

 - Some misidentify the end-of-message: this can cause the the characters in the last message frame to be lost or corrupted.
 - Some will wait until they hit a timeout before processing the message (usually N seconds of low RSSI and/or no valid bit/byte framing): this is less harmful but causes the message to be delayed while the timeout expires.

This PR adds a Terminator state which queues a Sync word and 16 Idle codewords (a full idle batch) after the end of the last batch. This works out at about half a second of idle traffic at 1200 baud (17 cws * 32 bits = 544 bits * 1/1200 ~= 0.45 sec). The benefit is the whole message is received correctly.

If the added transmit time is a problem, the tx-off delay could likely be reduced on the transmitter as mitigation.